### PR TITLE
Add CRuntime module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+*.xcodeproj
 
 ## Other
 *.moved-aside
@@ -35,9 +36,9 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
+Packages/
+Package.pins
+Package.resolved
 .build/
 
 # CocoaPods

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,8 @@
+{
+  "object": {
+    "pins": [
+
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "CRuntime",
+    products: [
+        .library(name: "CRuntime", targets: ["CRuntime"])
+    ],
+    targets: [
+        .systemLibrary(name: "CRuntime", path: "Sources/CRuntime")
+    ]
+)

--- a/Sources/CRuntime/CRuntime.h
+++ b/Sources/CRuntime/CRuntime.h
@@ -1,0 +1,6 @@
+#ifndef cruntime_h
+#define cruntime_h
+
+void swift_getFieldAt(const void *base, unsigned index, void (*callback)(const char *name, const void *type, void *ctx), void *callbackCtx);
+
+#endif

--- a/Sources/CRuntime/module.modulemap
+++ b/Sources/CRuntime/module.modulemap
@@ -1,0 +1,4 @@
+module CRuntime {
+    header "CRuntime.h"
+    export *
+}


### PR DESCRIPTION
Ref https://github.com/wickwirew/Runtime/pull/31#issuecomment-440097477

Okay, this took a minute. Thanks to [Fred Appelman](https://forums.swift.org/u/freda) for pointing out that there is nothing to build, so `swift build` and `swift package generate-xcodeproj` won't work. This was the crux of my understanding here.