### PR TITLE
change `id` to `void *`

### DIFF
--- a/Sources/CRuntime/CRuntime.h
+++ b/Sources/CRuntime/CRuntime.h
@@ -7,7 +7,7 @@ const void * _Nullable swift_getTypeByMangledNameInContext(
                         const void * _Nullable context,
                         const void * _Nullable const * _Nullable genericArgs);
 
-const id _Nullable swift_allocObject(
+const void * _Nullable swift_allocObject(
                     const void * _Nullable type,
                     int requiredSize,
                     int requiredAlignmentMask);


### PR DESCRIPTION
Ref https://github.com/wickwirew/CRuntime/issues/6

Seems to work locally; haven't tested it on Linux yet...