### PR TITLE
Update CRuntime.podspec

### DIFF
--- a/CRuntime.podspec
+++ b/CRuntime.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
     s.author       = { "Wesley Wickwire" => "wickwirew@gmail.com" }
     s.platform     = :ios, "9.0"
     s.source       = { :git => "https://github.com/wickwirew/CRuntime.git", :tag => s.version }
-    s.source_files  = 'Sources/**/*'
+    s.source_files  = 'Sources/**/*.h'
 end


### PR DESCRIPTION
Fixes the warning:
```
:-1: no rule to process file 'Pods/CRuntime/Sources/CRuntime/module.modulemap' of type 'sourcecode.module-map' for architecture 'x86_64' (in target 'CRuntime').
``` 

Please update the pod also as soon as you can.
Thanks.